### PR TITLE
fix/iSM996

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -3,7 +3,7 @@ name: automation
 on:
   push:
     branches:
-      - fix/iSM996
+      - feat/updated-models
 
   workflow_dispatch:
 
@@ -21,5 +21,5 @@ jobs:
     - name: Run the pipeline
       run: |
         cd latest-ecModels
-        git checkout fix/iSM996
+        git checkout feat/updated-models
         python3 run.py

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -3,7 +3,7 @@ name: automation
 on:
   push:
     branches:
-      - feat/updated-models
+      - fix/iSM996
 
   workflow_dispatch:
 
@@ -21,5 +21,5 @@ jobs:
     - name: Run the pipeline
       run: |
         cd latest-ecModels
-        git checkout feat/updated-models
+        git checkout fix/iSM996
         python3 run.py

--- a/config.ini
+++ b/config.ini
@@ -32,35 +32,35 @@ version = v2.0.1
 install_dir = GECKO/
 branch = devel
 
-[ecYeastGEM]
-type = 'gem'
-url = https://github.com/SysBioChalmers/yeast-GEM
-download_url =
-mat_filename =  /ModelFiles/mat/yeastGEM.mat
-mat_model = .model
-install_dir = yeast-GEM
-version = v8.3.1
-database_tag = sce
+;[ecYeastGEM]
+;type = 'gem'
+;url = https://github.com/SysBioChalmers/yeast-GEM
+;download_url =
+;mat_filename =  /ModelFiles/mat/yeastGEM.mat
+;mat_model = .model
+;install_dir = yeast-GEM
+;version = v8.3.1
+;database_tag = sce
 
-[ecHumanGEM]
-type = 'gem'
-url = https://github.com/SysBioChalmers/Human-GEM
-download_url =
-mat_filename = /model/Human-GEM.mat
-mat_model = .ihuman
-install_dir = Human-GEM
-version = v0
-database_tag = hsa
+;[ecHumanGEM]
+;type = 'gem'
+;url = https://github.com/SysBioChalmers/Human-GEM
+;download_url =
+;mat_filename = /model/Human-GEM.mat
+;mat_model = .ihuman
+;install_dir = Human-GEM
+;version = v0
+;database_tag = hsa
 
-[eciYali]
-type = 'gem'
-url = https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM
-download_url =
-mat_filename = /ModelFiles/mat/iYali.mat
-mat_model = .model
-install_dir = Yali-GEM
-version = v0
-database_tag = yli
+;[eciYali]
+;type = 'gem'
+;url = https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM
+;download_url =
+;mat_filename = /ModelFiles/mat/iYali.mat
+;mat_model = .model
+;install_dir = Yali-GEM
+;version = v0
+;database_tag = yli
 
 [eciSM966]
 type = 'gem'
@@ -71,13 +71,3 @@ mat_model = .model
 install_dir = Kmarx-GEM
 version = v0
 database_tag = kmx
-
-; [eciSM966]
-; type = 'gem'
-; url =
-; download_url = https://raw.githubusercontent.com/SysBioChalmers/Kluyveromyces_marxianus-GEM/master/modelFiles/mat/Kluyveromyces_marxianus-GEM.mat
-; mat_filename = /Kluyveromyces_marxianus-GEM.mat
-; mat_model = 
-; install_dir = Kmarx-GEM
-; version = v0
-; database_tag = kmx

--- a/config.ini
+++ b/config.ini
@@ -32,35 +32,35 @@ version = v2.0.1
 install_dir = GECKO/
 branch = devel
 
-;[ecYeastGEM]
-;type = 'gem'
-;url = https://github.com/SysBioChalmers/yeast-GEM
-;download_url =
-;mat_filename =  /ModelFiles/mat/yeastGEM.mat
-;mat_model = .model
-;install_dir = yeast-GEM
-;version = v8.3.1
-;database_tag = sce
+[ecYeastGEM]
+type = 'gem'
+url = https://github.com/SysBioChalmers/yeast-GEM
+download_url =
+mat_filename =  /ModelFiles/mat/yeastGEM.mat
+mat_model = .model
+install_dir = yeast-GEM
+version = v8.3.1
+database_tag = sce
 
-;[ecHumanGEM]
-;type = 'gem'
-;url = https://github.com/SysBioChalmers/Human-GEM
-;download_url =
-;mat_filename = /model/Human-GEM.mat
-;mat_model = .ihuman
-;install_dir = Human-GEM
-;version = v0
-;database_tag = hsa
+[ecHumanGEM]
+type = 'gem'
+url = https://github.com/SysBioChalmers/Human-GEM
+download_url =
+mat_filename = /model/Human-GEM.mat
+mat_model = .ihuman
+install_dir = Human-GEM
+version = v0
+database_tag = hsa
 
-;[eciYali]
-;type = 'gem'
-;url = https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM
-;download_url =
-;mat_filename = /ModelFiles/mat/iYali.mat
-;mat_model = .model
-;install_dir = Yali-GEM
-;version = v0
-;database_tag = yli
+[eciYali]
+type = 'gem'
+url = https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM
+download_url =
+mat_filename = /ModelFiles/mat/iYali.mat
+mat_model = .model
+install_dir = Yali-GEM
+version = v0
+database_tag = yli
 
 [eciSM966]
 type = 'gem'

--- a/config.ini
+++ b/config.ini
@@ -68,6 +68,6 @@ url = https://github.com/SysBioChalmers/Kluyveromyces_marxianus-GEM
 download_url =
 mat_filename = /modelFiles/mat/Kluyveromyces_marxianus-GEM.mat
 mat_model = .model
-install_dir = Kmarx-GEM
+install_dir = iSM966
 version = v0
 database_tag = kmx

--- a/eciSM966/scripts/manualModifications.m
+++ b/eciSM966/scripts/manualModifications.m
@@ -9,6 +9,8 @@ model            = removeRxns(model,'r_1913_REV');
 modifications{1} = [];
 modifications{2} = [];
 
+fprintf('Improving model with curated data...')
+
 for i = 1:length(model.rxns)
     reaction = model.rxnNames{i};
     %Find set of proteins present in rxn:
@@ -44,8 +46,11 @@ for i = 1:length(model.rxns)
             end
         end
     end
-    disp(['Improving model with curated data: Ready with rxn #' num2str(i)])
+    if rem(i,100) == 0 || i == length(model.rxns)
+        fprintf('.')
+    end
 end
+fprintf(' Done!\n')
 %%%%%%%%%%%%%%%%%%%%%%%%% Other manual changes: %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %model = otherChanges(model);
 % Remove repeated reactions (2017-01-16):


### PR DESCRIPTION
An empty `prot_abundance.txt` file has been added to `eciSM996/scripts` as discussed in [PR#124](https://github.com/SysBioChalmers/GECKO/pull/124#issuecomment-749556348) in GECKO. This change enables generation of a functional ecModel for iSM996 and all outputs comply with the expected format and content.