### PR TITLE
refactor: run automation on any branch except some

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -2,8 +2,10 @@ name: automation
 
 on:
   push:
-    branches:
-      - feat/updated-models
+    branches-ignore:
+      - 'master'
+      - 'main'
+      - 'update/**'
 
   workflow_dispatch:
 
@@ -13,13 +15,12 @@ jobs:
     timeout-minutes: 1200
 
     steps:
-    - name: Clone repository
+    - name: Clone repository on current branch
       run: |
-        rm -rf latest-ecModels
-        git clone https://github.com/MetabolicAtlas/ecModels latest-ecModels
+        rm -rf *
+        git clone https://github.com/MetabolicAtlas/ecModels --depth 1 --branch ${GITHUB_REF#refs/heads/} latest-ecModels
 
     - name: Run the pipeline
       run: |
         cd latest-ecModels
-        git checkout feat/updated-models
         python3 run.py


### PR DESCRIPTION
This pull request aim to remove the need to update the automation script for every custom branch. The goal is to have the automation run on any branch except `master`, `main`, or any of the `update/*` branches that get created by the pipeline itself, since that would be an infinite loop.
Another fix was to remove all existing files and folders before the pipeline starts, so that in case of error the files continue to exist in the runner until the next run.